### PR TITLE
Move async-std to the dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,13 @@ repository = "https://github.com/nthieu173/srt-rs"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dev-dependencies]
+async-std = { version ="1.8", features=["attributes"] }
 
 [dependencies]
 libsrt-sys = { path = "libsrt-sys", version = "1.4.13" }
 libc = "0.2"
 futures = "0.3"
-async-std = {version ="1.8", features=["attributes"]}
 os_socketaddr = "0.1.1"
 
 


### PR DESCRIPTION
It is not used in the main crate.